### PR TITLE
Update README for new organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Legacy organisation, stabilised-platform repository has been moved to [SUSF-Robotics-and-Software](https://github.com/SUSF-Robotics-and-Software/stabilised-platform)
+
 ## Logger
 
 The Logger module is for SD writing. It has two main functions:


### PR DESCRIPTION
SUSpaceFlight is the old organisation and SUSF-Robotics-and-Software is the new organisation so updated README to direct people to the stabilised platform repository in the new organisation.